### PR TITLE
Undo makeTransparent

### DIFF
--- a/Library/UINavigationBar+Addition.h
+++ b/Library/UINavigationBar+Addition.h
@@ -10,8 +10,19 @@
 
 @interface UINavigationBar (Addition)
 
+/**
+ * Hide 1px hairline of the nav bar
+ */
 - (void)hideBottomHairline;
+
+/**
+ * Show 1px hairline of the nav bar
+ */
 - (void)showBottomHairline;
+
+/**
+ * Makes the navigation bar background transparent.
+ */
 - (void)makeTransparent;
 
 /**

--- a/Library/UINavigationBar+Addition.h
+++ b/Library/UINavigationBar+Addition.h
@@ -14,4 +14,9 @@
 - (void)showBottomHairline;
 - (void)makeTransparent;
 
+/**
+ * Restores the default navigation bar appeareance
+ **/
+- (void)makeDefault;
+
 @end

--- a/Library/UINavigationBar+Addition.m
+++ b/Library/UINavigationBar+Addition.m
@@ -41,12 +41,26 @@
     return nil;
 }
 
+/**
+ * Makes the navigation bar background transparent.
+ */
 - (void)makeTransparent {
-    [self setTranslucent:YES];
-    [self setBackgroundImage:[[UIImage alloc] init] forBarMetrics:UIBarMetricsDefault];
-    self.backgroundColor = [UIColor clearColor];
-    self.shadowImage = [UIImage new];    // Hides the hairline
-    [self hideBottomHairline];
+  [self setTranslucent:YES];
+  [self setBackgroundImage:[[UIImage alloc] init] forBarMetrics:UIBarMetricsDefault];
+  self.backgroundColor = [UIColor clearColor];
+  self.shadowImage = [UIImage new];    // Hides the hairline
+  [self hideBottomHairline];
+}
+
+/**
+ * Restores the default navigation bar appeareance
+ */
+- (void)makeDefault {
+  [self setTranslucent:YES];
+  [self setBackgroundImage:nil forBarMetrics:UIBarMetricsDefault];
+  self.backgroundColor = nil;
+  self.shadowImage = nil;    // Hides the hairline
+  [self showBottomHairline];
 }
 
 

--- a/Library/UINavigationBar+Addition.m
+++ b/Library/UINavigationBar+Addition.m
@@ -10,17 +10,11 @@
 
 @implementation UINavigationBar (Addition)
 
-/**
- * Hide 1px hairline of the nav bar
- */
 - (void)hideBottomHairline {
     UIImageView *navBarHairlineImageView = [self findHairlineImageViewUnder:self];
     navBarHairlineImageView.hidden = YES;
 }
 
-/**
- * Show 1px hairline of the nav bar
- */
 - (void)showBottomHairline {
     // Show 1px hairline of translucent nav bar
     UIImageView *navBarHairlineImageView = [self findHairlineImageViewUnder:self];
@@ -41,9 +35,6 @@
     return nil;
 }
 
-/**
- * Makes the navigation bar background transparent.
- */
 - (void)makeTransparent {
   [self setTranslucent:YES];
   [self setBackgroundImage:[[UIImage alloc] init] forBarMetrics:UIBarMetricsDefault];
@@ -52,9 +43,6 @@
   [self hideBottomHairline];
 }
 
-/**
- * Restores the default navigation bar appeareance
- */
 - (void)makeDefault {
   [self setTranslucent:YES];
   [self setBackgroundImage:nil forBarMetrics:UIBarMetricsDefault];

--- a/UINavigationBar+Addition.xcodeproj/project.pbxproj
+++ b/UINavigationBar+Addition.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		3ECB1AF718D2D3B0008E2C3E /* UINavigationBar_AdditionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECB1AF618D2D3B0008E2C3E /* UINavigationBar_AdditionTests.m */; };
 		3ECB1B0318D2D41A008E2C3E /* UINavigationBar+Addition.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECB1B0218D2D41A008E2C3E /* UINavigationBar+Addition.m */; };
 		3ECB1B0418D2D41A008E2C3E /* UINavigationBar+Addition.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECB1B0218D2D41A008E2C3E /* UINavigationBar+Addition.m */; };
+		E6083D991BF3FEAF00B181C3 /* SecondViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6083D981BF3FEAF00B181C3 /* SecondViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +60,8 @@
 		3ECB1AF618D2D3B0008E2C3E /* UINavigationBar_AdditionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UINavigationBar_AdditionTests.m; sourceTree = "<group>"; };
 		3ECB1B0118D2D41A008E2C3E /* UINavigationBar+Addition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Addition.h"; sourceTree = "<group>"; };
 		3ECB1B0218D2D41A008E2C3E /* UINavigationBar+Addition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UINavigationBar+Addition.m"; sourceTree = "<group>"; };
+		E6083D971BF3FEAF00B181C3 /* SecondViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SecondViewController.h; sourceTree = "<group>"; };
+		E6083D981BF3FEAF00B181C3 /* SecondViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SecondViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,6 +128,8 @@
 				3ECB1ADD18D2D3AF008E2C3E /* Main_iPad.storyboard */,
 				3ECB1AE018D2D3B0008E2C3E /* ViewController.h */,
 				3ECB1AE118D2D3B0008E2C3E /* ViewController.m */,
+				E6083D971BF3FEAF00B181C3 /* SecondViewController.h */,
+				E6083D981BF3FEAF00B181C3 /* SecondViewController.m */,
 				3ECB1AE318D2D3B0008E2C3E /* Images.xcassets */,
 				3ECB1ACF18D2D3AF008E2C3E /* Supporting Files */,
 			);
@@ -267,6 +272,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6083D991BF3FEAF00B181C3 /* SecondViewController.m in Sources */,
 				3ECB1AE218D2D3B0008E2C3E /* ViewController.m in Sources */,
 				3ECB1AD918D2D3AF008E2C3E /* AppDelegate.m in Sources */,
 				3ECB1AD518D2D3AF008E2C3E /* main.m in Sources */,
@@ -486,6 +492,7 @@
 				3ECB1AFC18D2D3B0008E2C3E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		3ECB1AFD18D2D3B0008E2C3E /* Build configuration list for PBXNativeTarget "UINavigationBar+AdditionTests" */ = {
 			isa = XCConfigurationList;
@@ -494,6 +501,7 @@
 				3ECB1AFF18D2D3B0008E2C3E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/UINavigationBar+Addition/Base.lproj/Main_iPad.storyboard
+++ b/UINavigationBar+Addition/Base.lproj/Main_iPad.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5023" systemVersion="13A603" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <scenes>
-        <!--class Prefix:identifier View Controller-->
+        <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
@@ -15,6 +16,7 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                 </viewController>
@@ -22,9 +24,4 @@
             </objects>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination"/>
-    </simulatedMetricsContainer>
 </document>

--- a/UINavigationBar+Addition/Base.lproj/Main_iPhone.storyboard
+++ b/UINavigationBar+Addition/Base.lproj/Main_iPhone.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="WTP-QT-dne">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="WTP-QT-dne">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <scenes>
         <!--Nav Bar Title-->
@@ -16,13 +16,48 @@
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
                         <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Ig-av-CD5">
+                                <rect key="frame" x="72" y="237" width="176" height="30"/>
+                                <animations/>
+                                <state key="normal" title="Push new View Controller"/>
+                                <connections>
+                                    <segue destination="T9f-rP-jbb" kind="push" id="fLL-Ov-BXK"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <animations/>
                         <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="8Ig-av-CD5" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="h7Q-V5-dNr"/>
+                            <constraint firstItem="8Ig-av-CD5" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="tb5-r1-LHh"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Nav Bar Title" id="DhN-1n-FdE"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="811" y="148"/>
+        </scene>
+        <!--Second View Controller-->
+        <scene sceneID="4EC-jm-IL9">
+            <objects>
+                <viewController id="T9f-rP-jbb" customClass="SecondViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="w5g-MA-e9Q"/>
+                        <viewControllerLayoutGuide type="bottom" id="alm-DZ-SEN"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="4I9-8r-hRn">
+                        <rect key="frame" x="0.0" y="64" width="320" height="504"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Zr4-KZ-1kL"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="N7r-mm-IWO" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1233" y="148"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="Imk-7B-SEt">
@@ -32,6 +67,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="0KI-px-x8Y">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <animations/>
                         <color key="barTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -44,9 +80,4 @@
             <point key="canvasLocation" x="339" y="148"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/UINavigationBar+Addition/SecondViewController.h
+++ b/UINavigationBar+Addition/SecondViewController.h
@@ -1,0 +1,13 @@
+//
+//  SecondViewController.h
+//  UINavigationBar+Addition
+//
+//  Created by Miguel Saiz on 11/11/15.
+//  Copyright © 2015 Just2us. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SecondViewController : UIViewController
+
+@end

--- a/UINavigationBar+Addition/SecondViewController.m
+++ b/UINavigationBar+Addition/SecondViewController.m
@@ -20,6 +20,8 @@
   
     UINavigationBar *navigationBar = self.navigationController.navigationBar;
     [navigationBar makeDefault];
+  
+    navigationBar.tintColor = [UIColor whiteColor];
 }
 
 @end

--- a/UINavigationBar+Addition/SecondViewController.m
+++ b/UINavigationBar+Addition/SecondViewController.m
@@ -1,0 +1,25 @@
+//
+//  SecondViewController.m
+//  UINavigationBar+Addition
+//
+//  Created by Miguel Saiz on 11/11/15.
+//  Copyright © 2015 Just2us. All rights reserved.
+//
+
+#import "SecondViewController.h"
+#import "UINavigationBar+Addition.h"
+
+@interface SecondViewController ()
+
+@end
+
+@implementation SecondViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+  
+    UINavigationBar *navigationBar = self.navigationController.navigationBar;
+    [navigationBar makeDefault];
+}
+
+@end

--- a/UINavigationBar+Addition/ViewController.m
+++ b/UINavigationBar+Addition/ViewController.m
@@ -24,9 +24,12 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
+  
     UINavigationBar *navigationBar = self.navigationController.navigationBar;
+    // This code do make the navigation bar transparent is in the viewWillAppear to make the navigation bar background dissapear whenever this view is displayed.
+    // If the navigation bar is always hidden, then use this on the viewDidLoad
     [navigationBar makeTransparent];
+    navigationBar.tintColor = nil;
 }
 
 - (void)didReceiveMemoryWarning

--- a/UINavigationBar+Addition/ViewController.m
+++ b/UINavigationBar+Addition/ViewController.m
@@ -8,6 +8,7 @@
 
 #import "ViewController.h"
 #import "UINavigationBar+Addition.h"
+#import "SecondViewController.h"
 
 @interface ViewController ()
 
@@ -18,9 +19,13 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+}
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    
     UINavigationBar *navigationBar = self.navigationController.navigationBar;
-//    [navigationBar hideBottomHairline];
     [navigationBar makeTransparent];
 }
 


### PR DESCRIPTION
I added a new function called "makeDefault" which undos the changes done in "makeTransparent", turning the navigationBar back to its original state (with a shadow, background and bottomHairline).

I also added a quick example on how to change the navigationBar style on pushes. It does have a small problem when canceling the swipe gesture but otherwise correctly shows that it undos the work done by "makeTransparent".